### PR TITLE
使用正确的语言代码

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 baseURL: "https://yuanfan.rbind.io/"
-languageCode: zh-cn
+languageCode: zh-CN
 title: "earfanfan | 袁凡"
 theme: "hugo-theme-mini"
 


### PR DESCRIPTION
地区子标签需要用大写字母或数字。

参考资料：https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang

> Region subtag
>
> Optional. This subtag defines a dialect of the base language from a particular location, and is either 2 letters in ALLCAPS matching a  country code, or 3 numbers matching a non-country area.