### PR TITLE
增加网易云音乐、本地音乐、哔哩哔哩视频、本地视频嵌入功能。

### DIFF
--- a/themes/hugo-theme-mini/layouts/shortcodes/audio.html
+++ b/themes/hugo-theme-mini/layouts/shortcodes/audio.html
@@ -1,0 +1,4 @@
+<audio controls style="display: block; margin: 10px 0; box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);  outline: none; background-color: #f0f0f0;">
+  <source src="{{ .Get 0 }}" type="audio/mpeg">
+  Your browser does not support the audio element.
+</audio>

--- a/themes/hugo-theme-mini/layouts/shortcodes/bilibili.html
+++ b/themes/hugo-theme-mini/layouts/shortcodes/bilibili.html
@@ -1,0 +1,35 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+  <style type="text/css">
+      .bilibili_shortcodes {
+          position: relative;
+          width: 100%;
+          height: 0;
+          padding-bottom: 66%;
+          margin: auto;
+          overflow: hidden;
+          text-align: center;
+      }
+      /* 嵌入视频的宽高在这里调！ */
+      .bilibili_shortcodes iframe {
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          left: 0;
+          top: 0;
+      }
+  </style>
+  <title> 嵌入 Bilibili 视频的页面</title>
+</head>
+<body>
+<div class="bilibili_shortcodes">
+  <iframe 
+  src="https://player.bilibili.com/player.html?bvid={{.Get 0}}&page={{.Get 1 | default 1}}&high_quality=1&danmaku=0&autoplay=0&as_wide=0" 
+  scrolling="no" 
+  frameborder="0" 
+  allowfullscreen="true">
+</iframe>
+</div>
+</body>
+</html>

--- a/themes/hugo-theme-mini/layouts/shortcodes/music.html
+++ b/themes/hugo-theme-mini/layouts/shortcodes/music.html
@@ -1,0 +1,3 @@
+<iframe frameborder="no" border="0" marginwidth="0" marginheight="0" width="330" height="86" 
+src="https://music.163.com/outchain/player?type=2&id={{ .Get 0 }}&auto=1&height=66" 
+style="display: block;"></iframe>

--- a/themes/hugo-theme-mini/layouts/shortcodes/video.html
+++ b/themes/hugo-theme-mini/layouts/shortcodes/video.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<video width="100%" height="auto" controls preload="metadata" poster="{{ .Get 1 }}">
+    <source src="{{ .Get 0 }}" type="video/mp4">
+    Your browser does not support the video tag.
+  </video>


### PR DESCRIPTION
在`themes/layouts/`下新增文件夹`shortcodes`包含`music.html、audio.html、bilibili.html、video.html`，实现Markdownd文档嵌入网易云音乐、本地音乐、bilibili视频、本地视频功能。

嵌入方式：
网易云：{{< music 468176711 >}}
本地音乐：{{< audio "歌曲路径.mp3">}}
哔哩哔哩：{{< bilibili BV1nF411c7Ro>}}
本地视频：{{< video "视频路径.mp4" >}}

